### PR TITLE
Add macOS notification permission priming flow

### DIFF
--- a/SysInfo/CMakeLists.txt
+++ b/SysInfo/CMakeLists.txt
@@ -81,13 +81,17 @@ if(WIN32)
         )
 endif()
 
-# macOS: Info.plist + icns
+# macOS: Info.plist + icns + Objective-C++ notification helper
 if(APPLE)
     target_sources(SysInfo PRIVATE
         "${CMAKE_SOURCE_DIR}/resources/icons/sysinfo_icon.icns"
+        app/macos_notifications.mm
     )
     set_source_files_properties("${CMAKE_SOURCE_DIR}/resources/icons/sysinfo_icon.icns"
         PROPERTIES MACOSX_PACKAGE_LOCATION "Resources"
+    )
+    set_source_files_properties(app/macos_notifications.mm
+        PROPERTIES COMPILE_FLAGS "-fobjc-arc"
     )
     set_target_properties(SysInfo PROPERTIES
         MACOSX_BUNDLE TRUE
@@ -96,6 +100,10 @@ if(APPLE)
         MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
         MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
         MACOSX_BUNDLE_ICON_FILE "SysInfo_Icon.icns"
+    )
+    target_link_libraries(SysInfo PRIVATE
+        "-framework UserNotifications"
+        "-framework AppKit"
     )
 endif()
 

--- a/SysInfo/app/app.cpp
+++ b/SysInfo/app/app.cpp
@@ -5,6 +5,10 @@
 #include "../tray/tray_guide.h"
 #include "../utils/utils.h"
 
+#ifdef Q_OS_MAC
+#include "macos_notifications.h"
+#endif
+
 #include <QAction>
 #include <QApplication>
 #include <QClipboard>
@@ -38,6 +42,10 @@ void App::startApp()
     createContextMenu();
 
     trayIcon->show();
+
+#ifdef Q_OS_MAC
+    checkMacOSNotificationPermission();
+#endif
 
     QTimer::singleShot(60000, [this]() {
 
@@ -152,3 +160,55 @@ void App::quitApp() {
     if (reply == QMessageBox::Yes)
         qApp->quit();
 }
+
+#ifdef Q_OS_MAC
+void App::checkMacOSNotificationPermission()
+{
+    MacOSNotifications::getStatus([this](MacOSNotifications::Status status) {
+        if (status == MacOSNotifications::Status::Authorized)
+            return;
+
+        if (status == MacOSNotifications::Status::NotDetermined) {
+            // Permission priming: explain why before the OS dialog appears
+            auto reply = QMessageBox::information(
+                nullptr,
+                QObject::tr("Enable Notifications"),
+                QObject::tr("SysInfo displays notifications when it starts and when data "
+                            "is copied to the clipboard.\n\n"
+                            "Click OK to allow notifications — macOS will ask for confirmation."),
+                QMessageBox::Ok | QMessageBox::Cancel
+            );
+
+            if (reply != QMessageBox::Ok)
+                return;
+
+            MacOSNotifications::requestPermission([](bool granted) {
+                if (!granted) {
+                    auto reply = QMessageBox::warning(
+                        nullptr,
+                        QObject::tr("Notifications Disabled"),
+                        QObject::tr("Notifications were not allowed.\n\n"
+                                    "To enable them later, go to:\n"
+                                    "System Settings → Notifications → SysInfo"),
+                        QMessageBox::Open | QMessageBox::Close
+                    );
+                    if (reply == QMessageBox::Open)
+                        MacOSNotifications::openSystemNotificationSettings();
+                }
+            });
+
+        } else { // Denied
+            auto reply = QMessageBox::warning(
+                nullptr,
+                QObject::tr("Notifications Disabled"),
+                QObject::tr("SysInfo notifications are disabled in System Settings.\n\n"
+                            "To enable them, go to:\n"
+                            "System Settings → Notifications → SysInfo"),
+                QMessageBox::Open | QMessageBox::Close
+            );
+            if (reply == QMessageBox::Open)
+                MacOSNotifications::openSystemNotificationSettings();
+        }
+    });
+}
+#endif

--- a/SysInfo/app/app.h
+++ b/SysInfo/app/app.h
@@ -33,6 +33,10 @@ private:
     void createContextMenu();
     void startTrayUpdateTimer();
 
+#ifdef Q_OS_MAC
+    void checkMacOSNotificationPermission();
+#endif
+
 private slots:
     void showTrayGuide();
     void copyToClipboard();

--- a/SysInfo/app/macos_notifications.h
+++ b/SysInfo/app/macos_notifications.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#ifdef Q_OS_MAC
+
+#include <functional>
+
+/**
+ * @brief Thin C++ wrapper around UNUserNotificationCenter for macOS.
+ *
+ * All callbacks are delivered on the main thread.
+ */
+class MacOSNotifications
+{
+public:
+    enum class Status {
+        NotDetermined,
+        Authorized,
+        Denied
+    };
+
+    /** Asynchronously query the current notification authorization status. */
+    static void getStatus(std::function<void(Status)> callback);
+
+    /** Request notification authorization from the OS.
+     *  The OS dialog is shown at most once; subsequent calls return the
+     *  stored decision without prompting the user again. */
+    static void requestPermission(std::function<void(bool granted)> callback);
+
+    /** Open System Settings → Notifications so the user can re-enable manually. */
+    static void openSystemNotificationSettings();
+};
+
+#endif // Q_OS_MAC

--- a/SysInfo/app/macos_notifications.mm
+++ b/SysInfo/app/macos_notifications.mm
@@ -1,0 +1,49 @@
+#ifdef Q_OS_MAC
+
+#include "macos_notifications.h"
+
+#import <UserNotifications/UserNotifications.h>
+#import <AppKit/AppKit.h>
+
+void MacOSNotifications::getStatus(std::function<void(Status)> callback)
+{
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *settings) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            switch (settings.authorizationStatus) {
+                case UNAuthorizationStatusAuthorized:
+                case UNAuthorizationStatusProvisional:
+                    callback(Status::Authorized);
+                    break;
+                case UNAuthorizationStatusDenied:
+                    callback(Status::Denied);
+                    break;
+                default: // UNAuthorizationStatusNotDetermined / Ephemeral
+                    callback(Status::NotDetermined);
+                    break;
+            }
+        });
+    }];
+}
+
+void MacOSNotifications::requestPermission(std::function<void(bool)> callback)
+{
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    UNAuthorizationOptions options =
+        UNAuthorizationOptionAlert |
+        UNAuthorizationOptionSound;
+    [center requestAuthorizationWithOptions:options
+                          completionHandler:^(BOOL granted, NSError *) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            callback(granted);
+        });
+    }];
+}
+
+void MacOSNotifications::openSystemNotificationSettings()
+{
+    NSURL *url = [NSURL URLWithString:@"x-apple.systempreferences:com.apple.preference.notifications"];
+    [[NSWorkspace sharedWorkspace] openURL:url];
+}
+
+#endif // Q_OS_MAC

--- a/SysInfo/resources/Info.plist
+++ b/SysInfo/resources/Info.plist
@@ -20,6 +20,8 @@
     <key>NSHumanReadableCopyright</key>
 	<string>© 2025 Kirill Bitskyi for Pivdenny</string>
     <key>GitHub</key>
-	<string>https://github.com/1minEpowMinX/SysInfo</string>   
+	<string>https://github.com/1minEpowMinX/SysInfo</string>
+    <key>NSUserNotificationUsageDescription</key>
+	<string>SysInfo displays notifications when it starts and when data is copied to the clipboard.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Before the OS permission dialog appears, show a custom Qt dialog explaining why SysInfo needs notification access. If the user denies or has previously denied, guide them to System Settings → Notifications → SysInfo via a deep link.

- Add macos_notifications.h/.mm (UNUserNotificationCenter wrapper)
- Call checkMacOSNotificationPermission() at startup on macOS
- Link UserNotifications and AppKit frameworks
- Add NSUserNotificationUsageDescription to Info.plist