### PR TITLE
docs: bump version to 3.0.0 and add Windows Event Log registration step

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,15 @@
 ```sh
 # Linux
 sudo apt install p7zip-full
-sudo 7z x SysInfo-2.0.0-linux-x64.7z -o/usr/bin/
+sudo 7z x SysInfo-3.0.0-linux-x64.7z -o/usr/bin/
 
 # MacOS:
 brew install p7zip
-sudo 7z x SysInfo-2.0.0-macos-x64.7z -o/usr/local/bin/
+sudo 7z x SysInfo-3.0.0-macos-x64.7z -o/usr/local/bin/
 
 # Windows:
-"C:\Program Files\7-Zip\7z.exe" x SysInfo-2.0.0-windows-x64.7z -o"C:\Program Files\"
+New-EventLog -LogName "SysInfo" -Source "SysInfo" -MaximumSize 5MB
+"C:\Program Files\7-Zip\7z.exe" x SysInfo-3.0.0-windows-x64.7z -o"C:\Program Files\"
 ```
 
 ### 3. Add to startup

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -40,14 +40,15 @@
 ```sh
 # Linux
 sudo apt install p7zip-full
-sudo 7z x SysInfo-2.0.0-linux-x64.7z -o/usr/bin/
+sudo 7z x SysInfo-3.0.0-linux-x64.7z -o/usr/bin/
 
 # MacOS:
 brew install p7zip
-sudo 7z x SysInfo-2.0.0-macos-x64.7z -o/usr/local/bin/
+sudo 7z x SysInfo-3.0.0-macos-x64.7z -o/usr/local/bin/
 
 # Windows:
-"C:\Program Files\7-Zip\7z.exe" x SysInfo-2.0.0-windows-x64.7z -o"C:\Program Files\"
+New-EventLog -LogName "SysInfo" -Source "SysInfo" -MaximumSize 5MB
+"C:\Program Files\7-Zip\7z.exe" x SysInfo-3.0.0-windows-x64.7z -o"C:\Program Files\"
 ```
 
 ### 3. Добавить в автозагрузку

--- a/docs/README.uk.md
+++ b/docs/README.uk.md
@@ -40,14 +40,15 @@
 ```sh
 # Linux
 sudo apt install p7zip-full
-sudo 7z x SysInfo-2.0.0-linux-x64.7z -o/usr/bin/
+sudo 7z x SysInfo-3.0.0-linux-x64.7z -o/usr/bin/
 
 # MacOS:
 brew install p7zip
-sudo 7z x SysInfo-2.0.0-macos-x64.7z -o/usr/local/bin/
+sudo 7z x SysInfo-3.0.0-macos-x64.7z -o/usr/local/bin/
 
 # Windows:
-"C:\Program Files\7-Zip\7z.exe" x SysInfo-2.0.0-windows-x64.7z -o"C:\Program Files\"
+New-EventLog -LogName "SysInfo" -Source "SysInfo" -MaximumSize 5MB
+"C:\Program Files\7-Zip\7z.exe" x SysInfo-3.0.0-windows-x64.7z -o"C:\Program Files\"
 ```
 
 ### 3. Додати до автозавантаження


### PR DESCRIPTION
## Summary

- Updated archive filenames in install guide from `2.0.0` to `3.0.0` across EN, RU, and UK READMEs
- Added `New-EventLog` registration step (5 MB limit) to the Windows install block

## Test plan
- [x] Verify install commands reference `SysInfo-3.0.0-*` filenames
- [x] Verify `New-EventLog` command is present in the Windows block of all three READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)