### PR TITLE
fix(ext): prevent spurious history saves + bump to v2.0.1

### DIFF
--- a/SysInfoExtension/chromium_manifest.json
+++ b/SysInfoExtension/chromium_manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "__MSG_extName__",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "__MSG_extDesc__",
 	"default_locale": "en",
 	"permissions": [

--- a/SysInfoExtension/content/content_script.bundle.js
+++ b/SysInfoExtension/content/content_script.bundle.js
@@ -140,6 +140,10 @@
       pendingInsertion = null;
       return;
     }
+    if (!isTicketAllowed(pendingInsertion.formPath)) {
+      pendingInsertion = null;
+      return;
+    }
     const created = detectCreatedTicket(location.pathname);
     if (!created || created.portalId !== pendingInsertion.portalId) {
       pendingInsertion = null;

--- a/SysInfoExtension/content/content_script.bundle.js
+++ b/SysInfoExtension/content/content_script.bundle.js
@@ -103,7 +103,7 @@
   // content/lib/history.js
   var pendingInsertion = null;
   function markPendingInsertion(portalId, typeId) {
-    pendingInsertion = { portalId, typeId, at: Date.now() };
+    pendingInsertion = { portalId, typeId, formPath: location.pathname, at: Date.now() };
   }
   function detectCreatedTicket(pathname) {
     const m = pathname.match(TICKET_PATH_RE);
@@ -130,15 +130,21 @@
       observer.observe(document.body, { childList: true, subtree: true });
     });
   }
-  function finalizeHistoryIfCreated() {
+  function finalizeHistoryIfCreated(fromPath) {
     if (!pendingInsertion) return;
     if (Date.now() - pendingInsertion.at > PENDING_TTL_MS) {
       pendingInsertion = null;
       return;
     }
+    if (fromPath !== void 0 && fromPath !== pendingInsertion.formPath) {
+      pendingInsertion = null;
+      return;
+    }
     const created = detectCreatedTicket(location.pathname);
-    if (!created) return;
-    if (created.portalId !== pendingInsertion.portalId) return;
+    if (!created || created.portalId !== pendingInsertion.portalId) {
+      pendingInsertion = null;
+      return;
+    }
     slog("history: ticket created", created);
     const pending = pendingInsertion;
     pendingInsertion = null;
@@ -169,7 +175,7 @@
     const prev = lastPathname;
     lastPathname = location.pathname;
     slog("url change", { from: prev, to: lastPathname });
-    finalizeHistoryIfCreated();
+    finalizeHistoryIfCreated(prev);
   }
   function setupUrlWatcher() {
     setInterval(checkUrlChange, URL_TICK_MS);

--- a/SysInfoExtension/content/lib/history.js
+++ b/SysInfoExtension/content/lib/history.js
@@ -6,16 +6,14 @@ import { PENDING_TTL_MS, TICKET_PATH_RE, TITLE_SELECTOR, TITLE_WAIT_MS, HISTORY_
 let pendingInsertion = null;
 
 /**
- * The function markPendingInsertion sets a pending insertion with the specified portalId, typeId, and
- * timestamp.
- * @param portalId - Portal ID is a unique identifier for a specific portal in the system. It helps to
- * distinguish one portal from another.
- * @param typeId - Type ID is a unique identifier that represents the type of data or object being
- * inserted into the system. It helps differentiate between different types of data or objects within
- * the system.
+ * The function `markPendingInsertion` records that sysinfo was just inserted into the form at the
+ * current pathname. The record is later matched against a ticket-page URL by
+ * `finalizeHistoryIfCreated` to confirm the ticket was actually created from this form.
+ * @param portalId - The portal ID extracted from the form URL.
+ * @param typeId - The ticket-type ID extracted from the form URL.
  */
 export function markPendingInsertion(portalId, typeId) {
-	pendingInsertion = { portalId, typeId, at: Date.now() };
+	pendingInsertion = { portalId, typeId, formPath: location.pathname, at: Date.now() };
 }
 
 /**
@@ -65,14 +63,21 @@ function waitForHeading() {
 }
 
 /**
- * The function `finalizeHistoryIfCreated` checks if a pending ticket insertion has expired, detects a
- * created ticket, and saves its details to browser storage.
- * @returns If the `pendingInsertion` is not set, the function will return early. If the difference
- * between the current time and the time of the pending insertion is greater than the `PENDING_TTL_MS`,
- * then `null` will be returned. If the `created` ticket is not detected or if the `portalId` of the
- * created ticket does not match the `portalId` of the
+ * The function `finalizeHistoryIfCreated` checks whether the current page is the ticket that was
+ * created from the pending form insertion and, if so, saves an entry to history.
+ *
+ * `fromPath` must be the pathname from which the SPA navigation originated. If provided, the
+ * function requires that it matches the form path recorded by `markPendingInsertion` — any other
+ * navigation (user clicking a link, back/forward) clears the pending state and returns without
+ * saving, preventing false history entries for tickets the user merely visited.
+ *
+ * All mismatching or ambiguous conditions clear `pendingInsertion` rather than leaving it alive for
+ * a later URL change, which was the source of the false-positive bug.
+ *
+ * @param fromPath - The `location.pathname` before the navigation that triggered this call, or
+ * `undefined` when called at bootstrap (in which case the form-path guard is skipped).
  */
-export function finalizeHistoryIfCreated() {
+export function finalizeHistoryIfCreated(fromPath) {
 	if (!pendingInsertion) return;
 
 	if (Date.now() - pendingInsertion.at > PENDING_TTL_MS) {
@@ -80,9 +85,18 @@ export function finalizeHistoryIfCreated() {
 		return;
 	}
 
+	// Navigation must originate directly from the form that recorded the insertion.
+	// Any intermediate stop (another page, a different form) invalidates the pending state.
+	if (fromPath !== undefined && fromPath !== pendingInsertion.formPath) {
+		pendingInsertion = null;
+		return;
+	}
+
 	const created = detectCreatedTicket(location.pathname);
-	if (!created) return;
-	if (created.portalId !== pendingInsertion.portalId) return;
+	if (!created || created.portalId !== pendingInsertion.portalId) {
+		pendingInsertion = null;
+		return;
+	}
 
 	slog("history: ticket created", created);
 

--- a/SysInfoExtension/content/lib/history.js
+++ b/SysInfoExtension/content/lib/history.js
@@ -2,6 +2,7 @@
 
 import { slog } from "./compat.js";
 import { PENDING_TTL_MS, TICKET_PATH_RE, TITLE_SELECTOR, TITLE_WAIT_MS, HISTORY_KEY } from "./constants.js";
+import { isTicketAllowed } from "./portals.js";
 
 let pendingInsertion = null;
 
@@ -66,13 +67,15 @@ function waitForHeading() {
  * The function `finalizeHistoryIfCreated` checks whether the current page is the ticket that was
  * created from the pending form insertion and, if so, saves an entry to history.
  *
- * `fromPath` must be the pathname from which the SPA navigation originated. If provided, the
- * function requires that it matches the form path recorded by `markPendingInsertion` — any other
- * navigation (user clicking a link, back/forward) clears the pending state and returns without
- * saving, preventing false history entries for tickets the user merely visited.
+ * Two guards are applied before saving:
+ *  1. **Form-path guard** — `fromPath` must equal the pathname recorded by `markPendingInsertion`.
+ *     Any intermediate navigation (back/forward, external link) clears the pending state so stale
+ *     records cannot match a later, unrelated ticket visit.
+ *  2. **Whitelist re-check** — `isTicketAllowed` is called against the stored form path to confirm
+ *     the portal/type pair is still in the user's whitelist at finalization time.
  *
  * All mismatching or ambiguous conditions clear `pendingInsertion` rather than leaving it alive for
- * a later URL change, which was the source of the false-positive bug.
+ * a later URL change.
  *
  * @param fromPath - The `location.pathname` before the navigation that triggered this call, or
  * `undefined` when called at bootstrap (in which case the form-path guard is skipped).
@@ -85,9 +88,14 @@ export function finalizeHistoryIfCreated(fromPath) {
 		return;
 	}
 
-	// Navigation must originate directly from the form that recorded the insertion.
-	// Any intermediate stop (another page, a different form) invalidates the pending state.
+	// Guard 1: navigation must originate directly from the form that recorded the insertion.
 	if (fromPath !== undefined && fromPath !== pendingInsertion.formPath) {
+		pendingInsertion = null;
+		return;
+	}
+
+	// Guard 2: re-verify the portal/type pair is still in the whitelist.
+	if (!isTicketAllowed(pendingInsertion.formPath)) {
 		pendingInsertion = null;
 		return;
 	}

--- a/SysInfoExtension/content/lib/url_watcher.js
+++ b/SysInfoExtension/content/lib/url_watcher.js
@@ -8,16 +8,16 @@ let lastPathname = location.pathname;
 
 /**
  * The function `checkUrlChange` detects SPA navigations by comparing the current
- * `location.pathname` to the last recorded value. When a change is found, it updates the stored
- * pathname, emits a diagnostic log, and delegates to `finalizeHistoryIfCreated` so that any
- * pending ticket insertion is committed before the page context shifts.
+ * `location.pathname` to the last recorded value. When a change is found it updates the stored
+ * pathname, emits a diagnostic log, and calls `finalizeHistoryIfCreated` with the previous
+ * pathname so the history logic can verify the navigation originated from the correct form.
  */
 function checkUrlChange() {
 	if (location.pathname === lastPathname) return;
 	const prev = lastPathname;
 	lastPathname = location.pathname;
 	slog("url change", { from: prev, to: lastPathname });
-	finalizeHistoryIfCreated();
+	finalizeHistoryIfCreated(prev);
 }
 
 /**

--- a/SysInfoExtension/firefox_manifest.json
+++ b/SysInfoExtension/firefox_manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "__MSG_extName__",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "__MSG_extDesc__",
 	"default_locale": "en",
 	"permissions": [


### PR DESCRIPTION
## Summary

Fixes two related bugs in the extension's history module that caused tickets
to be saved in history even when system info was **not** inserted from the form.

### Bug 1 — stale `pendingInsertion` state (ee691ce)

- `finalizeHistoryIfCreated()` did not clear `pendingInsertion` on non-ticket
  or portal-mismatch navigations, so a later unrelated visit to any same-portal
  ticket would trigger a spurious save.
- No check that the navigation came directly from the recorded form — a user
  could fill a form, navigate elsewhere, then browse to an existing ticket and
  have it saved as if data was inserted there.

**Fix:** `markPendingInsertion` now records `formPath` (`location.pathname` at
insertion time). `url_watcher` passes `prevPath` to `finalizeHistoryIfCreated`.
Any navigation that did not originate from that exact form path clears
`pendingInsertion` immediately. All early-exit branches also clear
`pendingInsertion` instead of silently returning.

### Bug 2 — whitelist race (4978a48)

Builds on Bug 1 fix: `isTicketAllowed()` is now re-checked at finalization time
against the stored `formPath` to guard against the portal/type pair being removed
from the whitelist between insertion and ticket creation.

### Version bump

Extension bumped to **v2.0.1** in both Chromium and Firefox manifests.

## Files changed

- `content/lib/history.js` — core logic fix
- `content/lib/url_watcher.js` — passes `prevPath` to finalizer
- `content/content_script.bundle.js` — rebuilt bundle

## Test plan

- [x] Fill the form and submit → ticket appears in history ✅
- [x] Fill the form, navigate away, then open an existing ticket → **no** history entry
- [x] Fill the form, submit, then open another ticket of the same portal → only the first entry saved
- [x] Remove portal from whitelist between form fill and ticket creation → no history entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)