### PR TITLE
Fix the delivery archive and attach it to the release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,15 +109,28 @@ jobs:
               run: cmake --build build --target delivery
 
             # Every one of these is a license text the delivery is required to carry.
-            - name: Check the delivery carries the license notices
+            - name: Check the delivery is complete
               shell: bash
               run: |
                   archive=$(find build -name 'SysInfo-*-x64.7z' | head -1)
                   test -n "$archive" || { echo "no delivery archive was written"; exit 1; }
+                  root=$(dirname "$archive")
+
+                  # Every one of these is a license text the delivery is
+                  # required to carry, and the install rules put them there.
                   for name in README.txt GPL-3.0.txt LGPL-3.0.txt THIRD-PARTY-NOTICES.txt; do
-                    found=$(find "$(dirname "$archive")" -name "$name" | head -1)
+                    found=$(find "$root" -name "$name" | head -1)
                     test -n "$found" || { echo "the delivery is missing $name"; exit 1; }
                   done
+
+                  # A delivery without these is the executable on its own,
+                  # which starts on no machine that lacks a system Qt. The
+                  # deploy step drops what it cannot resolve without saying so,
+                  # so nothing but the result is worth trusting.
+                  plugin=$(find "$root" -path '*/platforms/*' -type f | head -1)
+                  test -n "$plugin" || { echo "the delivery carries no platform plugin"; exit 1; }
+                  qtcore=$(find "$root" \( -name 'libQt6Core.so*' -o -name 'QtCore' \) -type f | head -1)
+                  test -n "$qtcore" || { echo "the delivery carries no Qt libraries"; exit 1; }
 
     hygiene:
         name: Repository hygiene

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,12 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.cliff.outputs.content }}
-          files: archives/*.7z
+          # The artifact keeps the directory the archive was written in, so
+          # the glob has to descend. fail_on_unmatched_files is what turns a
+          # glob that matches nothing into a failure rather than a release
+          # with no assets.
+          files: archives/**/*.7z
+          fail_on_unmatched_files: true
           # Left as a draft: the Windows archive is built elsewhere, and the
           # release is not publishable until it is attached.
           draft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ it by hand.
 * **ui:** Name the tray tooltip field after the boot time it carries ([`01c5f04`](https://github.com/1minEpowMinX/SysInfo/commit/01c5f04a8f4cbdaae8f3ad76d1c9c5b8273f330d))
 * **ui:** Report the tray-guide dismissal whichever way the window closes ([`d6a9c38`](https://github.com/1minEpowMinX/SysInfo/commit/d6a9c382bf441a90205bf99f5698556b791a0b65))
 * **sysinfo:** Stop including a header that cannot coexist with this namespace ([`b0cfb4b`](https://github.com/1minEpowMinX/SysInfo/commit/b0cfb4bd260c414e7563c4e52d2663894f95356e))
+* **sysinfo:** Deploy the Qt the Linux delivery ships ([`e220ce2`](https://github.com/1minEpowMinX/SysInfo/commit/e220ce21b23f9582d12e8bb7d73855f5874468b8))
 
 **Browser Extension**
 
@@ -151,6 +152,9 @@ it by hand.
 * **ci:** Build the delivery archive on Linux and macOS ([`7933954`](https://github.com/1minEpowMinX/SysInfo/commit/7933954b5dff44d0912eea05050cf3b592bf505e))
 * Refresh the changelog ([`922d856`](https://github.com/1minEpowMinX/SysInfo/commit/922d856d664780f135c6826a5cf9391b90be6ba1))
 * **release:** Attach the Linux and macOS archives to the release ([`6f71c0d`](https://github.com/1minEpowMinX/SysInfo/commit/6f71c0dc073a3071ae5ed912771ad0eaa6344c4f))
+* Render the pending work as part of 3.1.0 ([`bd968a6`](https://github.com/1minEpowMinX/SysInfo/commit/bd968a621245c4de065dd8e1e26f0f7a6ba60bad))
+* **release:** Attach the archives the release run built ([`75933a4`](https://github.com/1minEpowMinX/SysInfo/commit/75933a4ce15fb8c7e3391f0426f9b4ea98b2b5be))
+* **ci:** Hold the delivery to carrying a platform plugin and Qt ([`013297e`](https://github.com/1minEpowMinX/SysInfo/commit/013297e7e74dea97830882e6d263d118c5699f6c))
 
 **Browser Extension**
 

--- a/SysInfo/CMakeLists.txt
+++ b/SysInfo/CMakeLists.txt
@@ -297,10 +297,17 @@ endif()
 # Windows and Linux take the low-level command. macOS keeps the high-level
 # command, whose whole subject is the bundle layout.
 #
-# The paths name SYSINFO_DELIVERY_DIR rather than QT_DEPLOY_BIN_DIR, which
-# CMAKE_INSTALL_BINDIR sets from it. Deferring the expansion does not reach the
-# script: the versionless command forwards its arguments through a macro, which
-# expands the content a second time on the way.
+# EXECUTABLE names the binary in the build tree, not the installed copy. The
+# step finds what to deploy by resolving that binary's dependencies through its
+# own runtime path, and the installed copy carries INSTALL_RPATH, which leads
+# to the delivery directory and nowhere else: every Qt library comes back
+# unresolved, and unresolved dependencies are dropped without a word.
+#
+# LIB_DIR and PLUGINS_DIR name SYSINFO_DELIVERY_DIR rather than the
+# QT_DEPLOY_..._DIR variables that CMAKE_INSTALL_BINDIR sets from it. Deferring
+# the expansion does not reach the script: the versionless command forwards its
+# arguments through a macro, which expands the content a second time on the
+# way.
 if(APPLE)
     qt_generate_deploy_app_script(
         TARGET SysInfo
@@ -321,7 +328,7 @@ else()
         OUTPUT_SCRIPT deploy_script
         CONTENT "
 qt_deploy_runtime_dependencies(
-    EXECUTABLE \"${SYSINFO_DELIVERY_DIR}/$<TARGET_FILE_NAME:SysInfo>\"
+    EXECUTABLE \"$<TARGET_FILE:SysInfo>\"
     LIB_DIR \"${SYSINFO_DELIVERY_DIR}\"
     PLUGINS_DIR \"${SYSINFO_DELIVERY_DIR}\"
     NO_TRANSLATIONS
@@ -381,23 +388,27 @@ if(WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     list(APPEND LICENSE_NOTICES "${CMAKE_SOURCE_DIR}/../docs/LLVM-Apache-2.0.txt")
 endif()
 
+# The notices sit where the delivery presents them, which on macOS is the
+# bundle's resource directory. The build tree puts them in the same place, so
+# the bundle the deploy step carries into the archive holds one copy.
+if(APPLE)
+    set(LICENSE_NOTICE_DESTINATION "${SYSINFO_DELIVERY_DIR}/Contents/Resources")
+    set(LICENSE_NOTICE_BUILD_DIR "$<TARGET_BUNDLE_CONTENT_DIR:SysInfo>/Resources")
+else()
+    set(LICENSE_NOTICE_DESTINATION "${SYSINFO_DELIVERY_DIR}")
+    set(LICENSE_NOTICE_BUILD_DIR "$<TARGET_FILE_DIR:SysInfo>")
+endif()
+
 add_custom_command(TARGET SysInfo POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${LICENSE_NOTICES}
-        "$<TARGET_FILE_DIR:SysInfo>"
-    COMMENT "Copying the license notices next to the executable"
+        "${LICENSE_NOTICE_BUILD_DIR}"
+    COMMENT "Copying the license notices into the delivery"
     VERBATIM
 )
 
-# Installed from the same list that copies them into the build tree, so a
-# notice cannot reach one and miss the other. They travel inside the delivery
-# directory, which on macOS means the bundle's own resource directory.
-if(APPLE)
-    set(LICENSE_NOTICE_DESTINATION "${SYSINFO_DELIVERY_DIR}/Contents/Resources")
-else()
-    set(LICENSE_NOTICE_DESTINATION "${SYSINFO_DELIVERY_DIR}")
-endif()
-
+# Installed from the same list, so a notice cannot reach the build tree and
+# miss the archive.
 install(FILES ${LICENSE_NOTICES}
     DESTINATION "${LICENSE_NOTICE_DESTINATION}"
     COMPONENT delivery


### PR DESCRIPTION
Follows #16, which shipped three defects that the first release run exposed.

- The Linux archive held the executable and the license texts and nothing to run them with. `qt_deploy_runtime_dependencies` resolves dependencies through the binary's own runtime path, and it was reading the installed copy, whose `INSTALL_RPATH` is `$ORIGIN`. Every Qt library came back unresolved and was dropped silently. It now reads the build-tree binary, and the delivery carries 68 files instead of 5.
- The release went up with no assets: `upload-artifact` keeps the directory the archive was written in, so the asset glob missed by one level. Fixed, and `fail_on_unmatched_files` now turns that class of miss into a failed run.
- The CI check read only the license texts, so the hollow archive passed it. It now asserts a platform plugin and the Qt libraries are present.

Also: the macOS bundle carried the notices twice, once from the post-build copy and once from the install rule. Both now write to `Contents/Resources`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)